### PR TITLE
Convert payloads from generator to list

### DIFF
--- a/saleor/core/analytics.py
+++ b/saleor/core/analytics.py
@@ -60,7 +60,7 @@ def get_view_payloads(path, language, headers):
 
 
 def report_view(client_id, path, language, headers):
-    payloads = get_view_payloads(path, language, headers)
+    payloads = list(get_view_payloads(path, language, headers))
     extra_headers = {}
     user_agent = headers.get('HTTP_USER_AGENT', None)
     if user_agent:


### PR DESCRIPTION
Solves the error of kombu.exceptions.EncodeError: Object of type 'generator' is not JSON serializable,
when Google analytics is enabled by setting GOOGLE_ANALYTICS_TRACKING_ID.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
